### PR TITLE
Migrate from master-slave lingo

### DIFF
--- a/example/example3/pkg/user/storage/repository.go
+++ b/example/example3/pkg/user/storage/repository.go
@@ -39,7 +39,7 @@ func (s *Storage) User(u auth.User) (auth.User, error) {
 
 	lu := auth.User{}
 	
-	db, err := s.DbConns.GetMysqlConnection("slave")
+	db, err := s.DbConns.GetMysqlConnection("subordinate")
 	
 	if err != nil {
 		return lu, err


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.